### PR TITLE
Change FunctionExecutionContext namespace

### DIFF
--- a/src/ServiceBus.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/ServiceBus.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -1,11 +1,5 @@
 namespace NServiceBus.AzureFunctions
 {
-    public class FunctionExecutionContext
-    {
-        public FunctionExecutionContext(Microsoft.Azure.WebJobs.ExecutionContext executionContext, Microsoft.Extensions.Logging.ILogger logger) { }
-        public Microsoft.Azure.WebJobs.ExecutionContext ExecutionContext { get; }
-        public Microsoft.Extensions.Logging.ILogger Logger { get; }
-    }
     public abstract class ServerlessEndpointConfiguration
     {
         protected ServerlessEndpointConfiguration(string endpointName) { }
@@ -28,10 +22,16 @@ namespace NServiceBus.AzureFunctions
 }
 namespace NServiceBus
 {
-    public class FunctionEndpoint : NServiceBus.AzureFunctions.ServerlessEndpoint<NServiceBus.AzureFunctions.FunctionExecutionContext, NServiceBus.ServiceBusTriggeredEndpointConfiguration>
+    public class FunctionEndpoint : NServiceBus.AzureFunctions.ServerlessEndpoint<NServiceBus.FunctionExecutionContext, NServiceBus.ServiceBusTriggeredEndpointConfiguration>
     {
-        public FunctionEndpoint(System.Func<NServiceBus.AzureFunctions.FunctionExecutionContext, NServiceBus.ServiceBusTriggeredEndpointConfiguration> configurationFactory) { }
+        public FunctionEndpoint(System.Func<NServiceBus.FunctionExecutionContext, NServiceBus.ServiceBusTriggeredEndpointConfiguration> configurationFactory) { }
         public System.Threading.Tasks.Task Process(Microsoft.Azure.ServiceBus.Message message, Microsoft.Azure.WebJobs.ExecutionContext executionContext, Microsoft.Extensions.Logging.ILogger functionsLogger = null) { }
+    }
+    public class FunctionExecutionContext
+    {
+        public FunctionExecutionContext(Microsoft.Azure.WebJobs.ExecutionContext executionContext, Microsoft.Extensions.Logging.ILogger logger) { }
+        public Microsoft.Azure.WebJobs.ExecutionContext ExecutionContext { get; }
+        public Microsoft.Extensions.Logging.ILogger Logger { get; }
     }
     public class ServiceBusTriggeredEndpointConfiguration : NServiceBus.AzureFunctions.ServerlessEndpointConfiguration
     {

--- a/src/Shared/FunctionExecutionContext.cs
+++ b/src/Shared/FunctionExecutionContext.cs
@@ -1,4 +1,4 @@
-namespace NServiceBus.AzureFunctions
+namespace NServiceBus
 {
     using Microsoft.Azure.WebJobs;
     using Microsoft.Extensions.Logging;

--- a/src/StorageQueues.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/StorageQueues.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -1,11 +1,5 @@
 namespace NServiceBus.AzureFunctions
 {
-    public class FunctionExecutionContext
-    {
-        public FunctionExecutionContext(Microsoft.Azure.WebJobs.ExecutionContext executionContext, Microsoft.Extensions.Logging.ILogger logger) { }
-        public Microsoft.Azure.WebJobs.ExecutionContext ExecutionContext { get; }
-        public Microsoft.Extensions.Logging.ILogger Logger { get; }
-    }
     public abstract class ServerlessEndpointConfiguration
     {
         protected ServerlessEndpointConfiguration(string endpointName) { }
@@ -28,10 +22,16 @@ namespace NServiceBus.AzureFunctions
 }
 namespace NServiceBus
 {
-    public class FunctionEndpoint : NServiceBus.AzureFunctions.ServerlessEndpoint<NServiceBus.AzureFunctions.FunctionExecutionContext, NServiceBus.StorageQueueTriggeredEndpointConfiguration>
+    public class FunctionEndpoint : NServiceBus.AzureFunctions.ServerlessEndpoint<NServiceBus.FunctionExecutionContext, NServiceBus.StorageQueueTriggeredEndpointConfiguration>
     {
-        public FunctionEndpoint(System.Func<NServiceBus.AzureFunctions.FunctionExecutionContext, NServiceBus.StorageQueueTriggeredEndpointConfiguration> configurationFactory) { }
+        public FunctionEndpoint(System.Func<NServiceBus.FunctionExecutionContext, NServiceBus.StorageQueueTriggeredEndpointConfiguration> configurationFactory) { }
         public System.Threading.Tasks.Task Process(Microsoft.WindowsAzure.Storage.Queue.CloudQueueMessage message, Microsoft.Azure.WebJobs.ExecutionContext executionContext, Microsoft.Extensions.Logging.ILogger functionsLogger = null) { }
+    }
+    public class FunctionExecutionContext
+    {
+        public FunctionExecutionContext(Microsoft.Azure.WebJobs.ExecutionContext executionContext, Microsoft.Extensions.Logging.ILogger logger) { }
+        public Microsoft.Azure.WebJobs.ExecutionContext ExecutionContext { get; }
+        public Microsoft.Extensions.Logging.ILogger Logger { get; }
     }
     public class StorageQueueTriggeredEndpointConfiguration : NServiceBus.AzureFunctions.ServerlessEndpointConfiguration
     {


### PR DESCRIPTION
by moving it into core's root namespace, user's shouldn't always require to import the `NServiceBus.AzureFunctions` namespace when using the `FunctionEndpoint` ctor