### PR TITLE
Forward ConfigureServicesCore to inner transport

### DIFF
--- a/src/NServiceBus.AzureFunctions.AzureServiceBus/AzureServiceBusServerlessTransport.cs
+++ b/src/NServiceBus.AzureFunctions.AzureServiceBus/AzureServiceBusServerlessTransport.cs
@@ -29,6 +29,8 @@ public class AzureServiceBusServerlessTransport : TransportDefinition
         };
     }
 
+    protected override void ConfigureServicesCore(IServiceCollection services) => innerTransport.ConfigureServices(services);
+
     public string ConnectionName { get; set; } = DefaultServiceBusConnectionName;
 
     internal IInternalMessageProcessor MessageProcessor { get; private set; } = null!;

--- a/src/NServiceBus.AzureFunctions.AzureServiceBus/AzureServiceBusServerlessTransport.cs
+++ b/src/NServiceBus.AzureFunctions.AzureServiceBus/AzureServiceBusServerlessTransport.cs
@@ -76,13 +76,7 @@ public class AzureServiceBusServerlessTransport : TransportDefinition
     }
 
     public override IReadOnlyCollection<TransportTransactionMode> GetSupportedTransactionModes() => supportedTransactionModes;
-
-    public void RegisterServices(IServiceCollection services, string endpointName)
-    {
-        services.AddKeyedSingleton<IMessageProcessor>(endpointName, (sp, _) =>
-            new MessageProcessor(this, sp.GetRequiredKeyedService<NServiceBus.MultiHosting.EndpointStarter>(endpointName)));
-    }
-
+ 
     static AzureServiceBusTransport ConfigureTransportConnection(
         string connectionName,
         IConfiguration configuration,

--- a/src/NServiceBus.AzureFunctions.AzureServiceBus/FunctionsHostApplicationBuilderExtensions.cs
+++ b/src/NServiceBus.AzureFunctions.AzureServiceBus/FunctionsHostApplicationBuilderExtensions.cs
@@ -1,6 +1,7 @@
 namespace NServiceBus;
 
 using System;
+using AzureFunctions.AzureServiceBus;
 using Microsoft.Azure.Functions.Worker.Builder;
 using Microsoft.Extensions.Azure;
 using Microsoft.Extensions.DependencyInjection;
@@ -23,6 +24,7 @@ public static class FunctionsHostApplicationBuilderExtensions
             configure(endpoint);
         });
 
-        transport.RegisterServices(builder.Services, endpointName);
+        builder.Services.AddKeyedSingleton<IMessageProcessor>(endpointName, (sp, _) =>
+            new MessageProcessor(transport, sp.GetRequiredKeyedService<MultiHosting.EndpointStarter>(endpointName)));
     }
 }


### PR DESCRIPTION
- forwards ConfigureServicesCore to inner
- IMessageProcessor DI set on Functions builder rather than in transport