### PR TITLE
Re-enable integration test

### DIFF
--- a/src/AcceptanceTests/IntegrationTest.cs
+++ b/src/AcceptanceTests/IntegrationTest.cs
@@ -6,7 +6,7 @@ using global::IntegrationTest.Contracts;
 using NUnit.Framework;
 using Particular.Approvals;
 
-[TestFixture, Explicit]
+[TestFixture]
 [Parallelizable(ParallelScope.Fixtures)]
 public class IntegrationTest
 {

--- a/src/NServiceBus.AzureFunctions.AzureServiceBus/FunctionsHostApplicationBuilderExtensions.cs
+++ b/src/NServiceBus.AzureFunctions.AzureServiceBus/FunctionsHostApplicationBuilderExtensions.cs
@@ -19,7 +19,7 @@ public static class FunctionsHostApplicationBuilderExtensions
         var transport = GetAzureServiceBusTransport(endpointConfiguration.GetSettings());
 
         transport.ConnectionName = functionManifest.ConnectionSettingName;
-        builder.Services.AddNServiceBusEndpoint(endpointConfiguration);
+        builder.Services.AddNServiceBusEndpoint(endpointConfiguration, endpointConfiguration.EndpointName);
         builder.Services.AddKeyedSingleton<AzureServiceBusMessageProcessor>(functionManifest.Name, (_, _) => new AzureServiceBusMessageProcessor(transport, functionManifest.Name));
     }
 
@@ -29,7 +29,7 @@ public static class FunctionsHostApplicationBuilderExtensions
         var endpointConfiguration = FunctionEndpointConfigurationBuilder.BuildSendOnlyEndpointConfiguration(builder, endpointName, configure);
         _ = GetAzureServiceBusTransport(endpointConfiguration.GetSettings());
 
-        builder.Services.AddNServiceBusEndpoint(endpointConfiguration);
+        builder.Services.AddNServiceBusEndpoint(endpointConfiguration, endpointName);
     }
 
     static AzureServiceBusServerlessTransport GetAzureServiceBusTransport(SettingsHolder settings)


### PR DESCRIPTION
The integration test was disabled and made explicit on adoption of the latest Core alpha, and this PR fixes the cause of the problem. The IntegrationApp wasn't running (even locally) because the generated code that calls AddNServiceBusEndpoint was not providing the endpointIdentifier.