### PR TITLE
Adds a transitive NuGet props file to ensure consumer project exposes needed properties to the source generator

### DIFF
--- a/src/Custom.Build.props
+++ b/src/Custom.Build.props
@@ -11,6 +11,7 @@
 
   <ItemGroup>
     <CompilerVisibleProperty Include="OutputType" />
+    <CompilerVisibleProperty Include="FunctionsExecutionModel" />
     <CompilerVisibleProperty Include="AzureFunctionsVersion" />
     <CompilerVisibleProperty Include="RootNamespace" />
   </ItemGroup>

--- a/src/Custom.Build.props
+++ b/src/Custom.Build.props
@@ -9,11 +9,4 @@
     <RoslynPackagePathVersion>$(RoslynPackageVersion.Split(`.`)[0]).$(RoslynPackageVersion.Split(`.`)[1])</RoslynPackagePathVersion>
   </PropertyGroup>
 
-  <ItemGroup>
-    <CompilerVisibleProperty Include="OutputType" />
-    <CompilerVisibleProperty Include="FunctionsExecutionModel" />
-    <CompilerVisibleProperty Include="AzureFunctionsVersion" />
-    <CompilerVisibleProperty Include="RootNamespace" />
-  </ItemGroup>
-
 </Project>

--- a/src/IntegrationTestApp/IntegrationTestApp.csproj
+++ b/src/IntegrationTestApp/IntegrationTestApp.csproj
@@ -1,5 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+  <Import Project="..\NServiceBus.AzureFunctions.Common\NServiceBus.AzureFunctions.Common.props" />
+
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>

--- a/src/NServiceBus.AzureFunctions.Common/NServiceBus.AzureFunctions.Common.csproj
+++ b/src/NServiceBus.AzureFunctions.Common/NServiceBus.AzureFunctions.Common.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\NServiceBus.snk</AssemblyOriginatorKeyFile>
+    <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);AddPropsFileToPackage</TargetsForTfmSpecificContentInPackage>
   </PropertyGroup>
 
   <ItemGroup>
@@ -19,5 +20,11 @@
     <None Include="..\NServiceBus.AzureFunctions.Analyzer\bin\$(Configuration)\$(AnalyzerTargetFramework)\NServiceBus.AzureFunctions.Analyzer.dll" Pack="true" PackagePath="analyzers/dotnet/roslyn$(RoslynPackagePathVersion)/cs/NServiceBus.AzureFunctions.Analyzer.dll" Visible="false" />
     <None Include="..\NServiceBus.AzureFunctions.CodeFixes\bin\$(Configuration)\$(AnalyzerTargetFramework)\NServiceBus.AzureFunctions.CodeFixes.dll" Pack="true" PackagePath="analyzers/dotnet/roslyn$(RoslynPackagePathVersion)/cs/NServiceBus.AzureFunctions.CodeFixes.dll" Visible="false" />
   </ItemGroup>
+
+  <Target Name="AddPropsFileToPackage">
+    <ItemGroup>
+      <TfmSpecificPackageFile Include="NServiceBus.AzureFunctions.Common.props" PackagePath="build/$(TargetFramework);buildTransitive/$(TargetFramework)" />
+    </ItemGroup>
+  </Target>
 
 </Project>

--- a/src/NServiceBus.AzureFunctions.Common/NServiceBus.AzureFunctions.Common.csproj
+++ b/src/NServiceBus.AzureFunctions.Common/NServiceBus.AzureFunctions.Common.csproj
@@ -4,17 +4,21 @@
     <TargetFramework>net10.0</TargetFramework>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\NServiceBus.snk</AssemblyOriginatorKeyFile>
-    <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);AddPropsFileToPackage</TargetsForTfmSpecificContentInPackage>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup Label="Public dependencies">
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.52.0" />
     <PackageReference Include="NServiceBus" Version="10.2.0-alpha.6" />
   </ItemGroup>
 
-  <ItemGroup>
+  <ItemGroup Label="Private dependencies">
     <PackageReference Include="Particular.Packaging" Version="4.5.0" PrivateAssets="All" />
   </ItemGroup>
+
+  <PropertyGroup>
+    <Description>Shared source generator and hosting infrastructure for NServiceBus endpoints hosted in Azure Functions.</Description>
+    <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);AddPropsFileToPackage</TargetsForTfmSpecificContentInPackage>
+  </PropertyGroup>
 
   <ItemGroup>
     <None Include="..\NServiceBus.AzureFunctions.Analyzer\bin\$(Configuration)\$(AnalyzerTargetFramework)\NServiceBus.AzureFunctions.Analyzer.dll" Pack="true" PackagePath="analyzers/dotnet/roslyn$(RoslynPackagePathVersion)/cs/NServiceBus.AzureFunctions.Analyzer.dll" Visible="false" />

--- a/src/NServiceBus.AzureFunctions.Common/NServiceBus.AzureFunctions.Common.props
+++ b/src/NServiceBus.AzureFunctions.Common/NServiceBus.AzureFunctions.Common.props
@@ -1,0 +1,9 @@
+<Project>
+
+  <ItemGroup>
+    <CompilerVisibleProperty Include="OutputType" />
+    <CompilerVisibleProperty Include="FunctionsExecutionModel" />
+    <CompilerVisibleProperty Include="RootNamespace" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Adds a transitive NuGet props file so the source generators can detect Azure Functions host projects in package consumers without relying on repo-local build configuration.

## Changes

- pack `NServiceBus.AzureFunctions.Common.props` into `build/` and `buildTransitive/` from `NServiceBus.AzureFunctions.Common`
- move the required `CompilerVisibleProperty` items into that props file:
  - `OutputType`
  - `FunctionsExecutionModel`
  - `RootNamespace`
- remove those `CompilerVisibleProperty` entries from `src/Custom.Build.props`
- import `NServiceBus.AzureFunctions.Common.props` directly in `src/IntegrationTestApp/IntegrationTestApp.csproj` so the local integration app uses the same setup as package consumers

## Why

The composition generator depends on compiler-visible MSBuild properties to recognize the Azure Functions host project and emit `AddNServiceBusFunctions()`.

Previously, that worked in this repository because `Custom.Build.props` exposed those properties globally, but consumers referencing the NuGet package did not get the same configuration. By shipping the props file as a transitive package asset, consumers now get the required compiler-visible properties automatically.