### PR TITLE
Only allow the NServiceBusFunction attribute on methods

### DIFF
--- a/src/IntegrationTest.Sales/SalesEndpoint.cs
+++ b/src/IntegrationTest.Sales/SalesEndpoint.cs
@@ -6,10 +6,9 @@ using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.DependencyInjection;
 using NServiceBus.Transport.AzureServiceBus;
 
-// Cleanest pattern for single-function endpoints
-[NServiceBusFunction]
 public partial class SalesEndpoint
 {
+    [NServiceBusFunction]
     [Function("Sales")]
     public partial Task Sales(
         [ServiceBusTrigger("sales", Connection = "AzureWebJobsServiceBus", AutoCompleteMessages = false)]

--- a/src/IntegrationTest.Shipping/ShippingEndpoint.cs
+++ b/src/IntegrationTest.Shipping/ShippingEndpoint.cs
@@ -3,9 +3,9 @@ using IntegrationTest.Shared;
 using Microsoft.Azure.Functions.Worker;
 
 // Intentionally in the global namespace to make sure that the generator can handle it
-[NServiceBusFunction]
 public partial class ShippingEndpoint
 {
+    [NServiceBusFunction]
     [Function(nameof(Shipping))]
     public partial Task Shipping(
         [ServiceBusTrigger("shipping", AutoCompleteMessages = false)]

--- a/src/NServiceBus.AzureFunctions.Analyzer/FunctionCompositionGenerator.cs
+++ b/src/NServiceBus.AzureFunctions.Analyzer/FunctionCompositionGenerator.cs
@@ -1,6 +1,7 @@
 namespace NServiceBus.AzureFunctions.Analyzer;
 
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 [Generator]
 public sealed partial class FunctionCompositionGenerator : IIncrementalGenerator
@@ -14,7 +15,7 @@ public sealed partial class FunctionCompositionGenerator : IIncrementalGenerator
         var hasLocalFunctions = context.SyntaxProvider
             .ForAttributeWithMetadataName(
                 "NServiceBus.NServiceBusFunctionAttribute",
-                static (_, _) => true,
+                static (node, _) => node is MethodDeclarationSyntax,
                 static (_, _) => true)
             .Collect()
             .Select(static (matches, _) => matches.Length > 0)

--- a/src/NServiceBus.AzureFunctions.Analyzer/FunctionEndpointGenerator.Parser.cs
+++ b/src/NServiceBus.AzureFunctions.Analyzer/FunctionEndpointGenerator.Parser.cs
@@ -29,41 +29,9 @@ public sealed partial class FunctionEndpointGenerator
 
             return context.TargetSymbol switch
             {
-                INamedTypeSymbol classSymbol => ExtractFromClass(classSymbol, knownTypes, triggerDefinition, cancellationToken),
                 IMethodSymbol methodSymbol => ExtractFromMethod(methodSymbol, knownTypes, triggerDefinition, cancellationToken),
                 _ => FunctionSpecs.Empty
             };
-        }
-
-        static FunctionSpecs ExtractFromClass(INamedTypeSymbol classSymbol, FunctionEndpointGeneratorKnownTypes knownTypes, TriggerDefinition triggerDefinition, CancellationToken cancellationToken)
-        {
-            var functions = new List<FunctionSpec>();
-            var diagnostics = new List<Diagnostic>();
-
-            if (!IsPartial(classSymbol, cancellationToken))
-            {
-                diagnostics.Add(CreateDiagnostic(DiagnosticIds.ClassMustBePartialDescriptor, classSymbol, classSymbol.Name));
-            }
-
-            if (ImplementsIHandleMessages(classSymbol, knownTypes))
-            {
-                diagnostics.Add(CreateDiagnostic(DiagnosticIds.ShouldNotImplementIHandleMessagesDescriptor, classSymbol, classSymbol.Name));
-            }
-
-            foreach (var member in classSymbol.GetMembers())
-            {
-                cancellationToken.ThrowIfCancellationRequested();
-                if (member is IMethodSymbol method)
-                {
-                    var spec = ExtractFunctionSpec(method, knownTypes, triggerDefinition, diagnostics);
-                    if (spec is not null)
-                    {
-                        functions.Add(spec);
-                    }
-                }
-            }
-
-            return new FunctionSpecs(functions.ToImmutableEquatableArray(), diagnostics.ToImmutableEquatableArray());
         }
 
         static FunctionSpecs ExtractFromMethod(IMethodSymbol methodSymbol, FunctionEndpointGeneratorKnownTypes knownTypes, TriggerDefinition triggerDefinition, CancellationToken cancellationToken)
@@ -75,9 +43,16 @@ public sealed partial class FunctionEndpointGenerator
                 diagnostics.Add(CreateDiagnostic(DiagnosticIds.MethodMustBePartialDescriptor, methodSymbol, methodSymbol.Name));
             }
 
-            if (!IsPartial(methodSymbol.ContainingType, cancellationToken))
+            var classSymbol = methodSymbol.ContainingType;
+
+            if (!IsPartial(classSymbol, cancellationToken))
             {
-                diagnostics.Add(CreateDiagnostic(DiagnosticIds.ClassMustBePartialDescriptor, methodSymbol.ContainingType, methodSymbol.ContainingType.Name));
+                diagnostics.Add(CreateDiagnostic(DiagnosticIds.ClassMustBePartialDescriptor, classSymbol, classSymbol.Name));
+            }
+
+            if (ImplementsIHandleMessages(classSymbol, knownTypes))
+            {
+                diagnostics.Add(CreateDiagnostic(DiagnosticIds.ShouldNotImplementIHandleMessagesDescriptor, classSymbol, classSymbol.Name));
             }
 
             var spec = ExtractFunctionSpec(methodSymbol, knownTypes, triggerDefinition, diagnostics);

--- a/src/NServiceBus.AzureFunctions.Analyzer/FunctionEndpointGenerator.cs
+++ b/src/NServiceBus.AzureFunctions.Analyzer/FunctionEndpointGenerator.cs
@@ -1,7 +1,6 @@
 namespace NServiceBus.AzureFunctions.Analyzer;
 
-using System.Collections.Generic;
-using System.Collections.Immutable;
+using Core.Analyzer;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
@@ -30,13 +29,15 @@ public sealed partial class FunctionEndpointGenerator : IIncrementalGenerator
             .Collect()
             .SelectMany(static (results, _) =>
             {
-                var diagnostics = ImmutableHashSet.CreateBuilder(DiagnosticComparer.Instance);
+                // Diagnostics are deduplicated across all results to avoid reporting the same issue multiple times when it occurs in multiple functions.
+                // Diagnostics implements IEquatable so we can use HashSet to deduplicate. We are not using an immutable collection to build the intermediate
+                // result because we only care about the immutability of the final diagnostics collection.
+                var diagnostics = new HashSet<Diagnostic>();
                 foreach (var result in results)
                 {
                     diagnostics.UnionWith(result.Diagnostics);
                 }
-
-                return diagnostics.ToImmutable();
+                return diagnostics.ToImmutableEquatableArray();
             })
             .WithTrackingName(TrackingNames.Diagnostics);
 
@@ -61,43 +62,5 @@ public sealed partial class FunctionEndpointGenerator : IIncrementalGenerator
             IncrementalGeneratorInitializationContext context,
             TriggerDefinition triggerDefinition) =>
             context.CompilationProvider.Select((_, _) => triggerDefinition);
-    }
-
-    sealed class DiagnosticComparer : IEqualityComparer<Diagnostic>
-    {
-        public static DiagnosticComparer Instance { get; } = new();
-
-        public bool Equals(Diagnostic? x, Diagnostic? y)
-        {
-            if (ReferenceEquals(x, y))
-            {
-                return true;
-            }
-
-            if (x is null || y is null)
-            {
-                return false;
-            }
-
-            return x.Id == y.Id
-                   && x.Severity == y.Severity
-                   && x.WarningLevel == y.WarningLevel
-                   && x.GetMessage() == y.GetMessage()
-                   && Equals(x.Location, y.Location);
-        }
-
-        public int GetHashCode(Diagnostic obj)
-        {
-            unchecked
-            {
-                var hashCode = 17;
-                hashCode = (hashCode * 31) + obj.Id.GetHashCode();
-                hashCode = (hashCode * 31) + obj.Severity.GetHashCode();
-                hashCode = (hashCode * 31) + obj.WarningLevel.GetHashCode();
-                hashCode = (hashCode * 31) + obj.GetMessage().GetHashCode();
-                hashCode = (hashCode * 31) + (obj.Location?.GetHashCode() ?? 0);
-                return hashCode;
-            }
-        }
     }
 }

--- a/src/NServiceBus.AzureFunctions.Analyzer/FunctionEndpointGenerator.cs
+++ b/src/NServiceBus.AzureFunctions.Analyzer/FunctionEndpointGenerator.cs
@@ -1,5 +1,7 @@
 namespace NServiceBus.AzureFunctions.Analyzer;
 
+using System.Collections.Generic;
+using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
@@ -14,7 +16,7 @@ public sealed partial class FunctionEndpointGenerator : IIncrementalGenerator
         var extractionCandidates = context.SyntaxProvider
             .ForAttributeWithMetadataName(
                 "NServiceBus.NServiceBusFunctionAttribute",
-                predicate: static (node, _) => node is ClassDeclarationSyntax or MethodDeclarationSyntax,
+                predicate: static (node, _) => node is MethodDeclarationSyntax,
                 transform: static (ctx, _) => ctx);
 
         var triggerDefinitionProvider = CreateTriggerDefinitionProvider(context, triggerDefinition);
@@ -25,7 +27,17 @@ public sealed partial class FunctionEndpointGenerator : IIncrementalGenerator
             .WithTrackingName(TrackingNames.Extraction);
 
         var diagnostics = extractionResults
-            .SelectMany(static (result, _) => result.Diagnostics)
+            .Collect()
+            .SelectMany(static (results, _) =>
+            {
+                var diagnostics = ImmutableHashSet.CreateBuilder(DiagnosticComparer.Instance);
+                foreach (var result in results)
+                {
+                    diagnostics.UnionWith(result.Diagnostics);
+                }
+
+                return diagnostics.ToImmutable();
+            })
             .WithTrackingName(TrackingNames.Diagnostics);
 
         context.RegisterSourceOutput(diagnostics, static (spc, diag) =>
@@ -49,5 +61,43 @@ public sealed partial class FunctionEndpointGenerator : IIncrementalGenerator
             IncrementalGeneratorInitializationContext context,
             TriggerDefinition triggerDefinition) =>
             context.CompilationProvider.Select((_, _) => triggerDefinition);
+    }
+
+    sealed class DiagnosticComparer : IEqualityComparer<Diagnostic>
+    {
+        public static DiagnosticComparer Instance { get; } = new();
+
+        public bool Equals(Diagnostic? x, Diagnostic? y)
+        {
+            if (ReferenceEquals(x, y))
+            {
+                return true;
+            }
+
+            if (x is null || y is null)
+            {
+                return false;
+            }
+
+            return x.Id == y.Id
+                   && x.Severity == y.Severity
+                   && x.WarningLevel == y.WarningLevel
+                   && x.GetMessage() == y.GetMessage()
+                   && Equals(x.Location, y.Location);
+        }
+
+        public int GetHashCode(Diagnostic obj)
+        {
+            unchecked
+            {
+                var hashCode = 17;
+                hashCode = (hashCode * 31) + obj.Id.GetHashCode();
+                hashCode = (hashCode * 31) + obj.Severity.GetHashCode();
+                hashCode = (hashCode * 31) + obj.WarningLevel.GetHashCode();
+                hashCode = (hashCode * 31) + obj.GetMessage().GetHashCode();
+                hashCode = (hashCode * 31) + (obj.Location?.GetHashCode() ?? 0);
+                return hashCode;
+            }
+        }
     }
 }

--- a/src/NServiceBus.AzureFunctions.Analyzer/FunctionEndpointGenerator.cs
+++ b/src/NServiceBus.AzureFunctions.Analyzer/FunctionEndpointGenerator.cs
@@ -26,12 +26,14 @@ public sealed partial class FunctionEndpointGenerator : IIncrementalGenerator
             .WithTrackingName(TrackingNames.Extraction);
 
         var diagnostics = extractionResults
-            .Collect()
+            .Collect() // Materialize all results for cross-method diagnostic deduplication.
             .SelectMany(static (results, _) =>
             {
-                // Diagnostics are deduplicated across all results to avoid reporting the same issue multiple times when it occurs in multiple functions.
-                // Diagnostics implements IEquatable so we can use HashSet to deduplicate. We are not using an immutable collection to build the intermediate
-                // result because we only care about the immutability of the final diagnostics collection.
+                // DiagnosticWithInfo implements structural equality (Location, Info, AdditionalLocations)
+                // so HashSet deduplicates correctly. ImmutableEquatableArray enables incremental caching:
+                // unchanged documents reuse the same SyntaxTree references, so diagnostics compare equal
+                // across steps. Within an edited file, new tree references cause re-reporting, which is
+                // correct and cheap.
                 var diagnostics = new HashSet<Diagnostic>();
                 foreach (var result in results)
                 {

--- a/src/NServiceBus.AzureFunctions.Common/NServiceBusFunctionAttribute.cs
+++ b/src/NServiceBus.AzureFunctions.Common/NServiceBusFunctionAttribute.cs
@@ -1,10 +1,10 @@
 namespace NServiceBus;
 
 /// <summary>
-/// Marks a class or method as the source of an NServiceBus endpoint hosted in Azure Functions.
-/// The source generator produces the trigger function and endpoint registration code from types
+/// Marks a function method as the source of an NServiceBus endpoint hosted in Azure Functions.
+/// The source generator produces the trigger body and endpoint registration code from methods
 /// marked with this attribute.
 /// </summary>
-/// <remarks>The target method, and any class containing it, must be declared <c>partial</c> so the source generator can emit the trigger body.</remarks>
-[AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, Inherited = false)]
+/// <remarks>The target method, and the class containing it, must be declared <c>partial</c> so the source generator can emit the trigger body.</remarks>
+[AttributeUsage(AttributeTargets.Method, Inherited = false)]
 public sealed class NServiceBusFunctionAttribute : Attribute;

--- a/src/NServiceBus.AzureFunctions.Tests/ApprovalFiles/ApiApprovals.ApproveFunctionsComponentApi.approved.txt
+++ b/src/NServiceBus.AzureFunctions.Tests/ApprovalFiles/ApiApprovals.ApproveFunctionsComponentApi.approved.txt
@@ -32,7 +32,7 @@ namespace NServiceBus
             public void AddSendOnlyNServiceBusEndpoint(string endpointName, System.Action<NServiceBus.EndpointConfiguration, Microsoft.Extensions.DependencyInjection.IServiceCollection> configure) { }
         }
     }
-    [System.AttributeUsage(System.AttributeTargets.Class | System.AttributeTargets.Method, Inherited=false)]
+    [System.AttributeUsage(System.AttributeTargets.Method, Inherited=false)]
     public sealed class NServiceBusFunctionAttribute : System.Attribute
     {
         public NServiceBusFunctionAttribute() { }

--- a/src/Tests.Analyzers/FunctionEndpointGeneratorTests.cs
+++ b/src/Tests.Analyzers/FunctionEndpointGeneratorTests.cs
@@ -133,9 +133,9 @@ public class FunctionEndpointGeneratorTests
     const string FunctionClassShouldNotImplementIHandleMessages = """
          namespace Demo;
 
-         [NServiceBusFunction]
          public partial class Functions : IHandleMessages<ServiceBusReceivedMessage>
          {
+             [NServiceBusFunction]
              [Function("ProcessOrder")]
              public partial Task Run(
                  [ServiceBusTrigger("sales-queue", Connection = "AzureServiceBus")] ServiceBusReceivedMessage message,
@@ -156,6 +156,61 @@ public class FunctionEndpointGeneratorTests
              }
          }
          """;
+
+    [Test]
+    public void ReportsIHandleMessagesWarningOnlyOnceForMultipleAttributedMethods()
+    {
+        var result = SourceGeneratorTest.ForIncrementalGenerator<FunctionEndpointGenerator>()
+           .WithSource("""
+               namespace Demo;
+
+               public partial class Functions : IHandleMessages<ServiceBusReceivedMessage>
+               {
+                   [NServiceBusFunction]
+                   [Function("ProcessOrder")]
+                   public partial Task Run(
+                       [ServiceBusTrigger("sales-queue", Connection = "AzureServiceBus", AutoCompleteMessages = false)] ServiceBusReceivedMessage message,
+                       ServiceBusMessageActions messageActions,
+                       FunctionContext context,
+                       CancellationToken cancellationToken);
+
+                   [NServiceBusFunction]
+                   [Function("ProcessOrder2")]
+                   public partial Task Run2(
+                       [ServiceBusTrigger("sales-queue-2", Connection = "AzureServiceBus", AutoCompleteMessages = false)] ServiceBusReceivedMessage message,
+                       ServiceBusMessageActions messageActions,
+                       FunctionContext context,
+                       CancellationToken cancellationToken);
+
+                   public Task Handle(ServiceBusReceivedMessage message, IMessageHandlerContext context)
+                   {
+                       return Task.CompletedTask;
+                   }
+
+                   public static void ConfigureProcessOrder(EndpointConfiguration endpointConfiguration)
+                   {
+                   }
+
+                   public static void ConfigureProcessOrder2(EndpointConfiguration endpointConfiguration)
+                   {
+                   }
+               }
+               """)
+           .SuppressCompilationErrors()
+           .SuppressDiagnosticErrors()
+           .Run();
+
+        var diagnosticCount = 0;
+        foreach (var diagnostic in result.GeneratorDiagnostics)
+        {
+            if (diagnostic.Id == DiagnosticIds.ShouldNotImplementIHandleMessages)
+            {
+                diagnosticCount++;
+            }
+        }
+
+        Assert.That(diagnosticCount, Is.EqualTo(1));
+    }
 
     const string MultipleConfigureMethods = """
        namespace Demo;


### PR DESCRIPTION
Made NServiceBusFunctionAttribute method-only and aligned analyzer discovery with that model. Removed class-based extraction, moved sample endpoints to method annotations, and preserved the IHandleMessages<T> warning
  without duplicates, and added generator-level diagnostic deduplication.