### PR TITLE
Reference analyzer and fixer to avoid race conditions when packing

### DIFF
--- a/src/NServiceBus.AzureFunctions.Common/NServiceBus.AzureFunctions.Common.csproj
+++ b/src/NServiceBus.AzureFunctions.Common/NServiceBus.AzureFunctions.Common.csproj
@@ -13,15 +13,8 @@
 
   <ItemGroup Label="Private dependencies">
     <PackageReference Include="Particular.Packaging" Version="4.5.0" PrivateAssets="All" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\NServiceBus.AzureFunctions.Analyzer\NServiceBus.AzureFunctions.Analyzer.csproj"
-                      ReferenceOutputAssembly="false"
-                      PrivateAssets="all" />
-    <ProjectReference Include="..\NServiceBus.AzureFunctions.CodeFixes\NServiceBus.AzureFunctions.CodeFixes.csproj"
-                      ReferenceOutputAssembly="false"
-                      PrivateAssets="all" />
+    <ProjectReference Include="..\NServiceBus.AzureFunctions.Analyzer\NServiceBus.AzureFunctions.Analyzer.csproj" ReferenceOutputAssembly="false" PrivateAssets="All" />
+    <ProjectReference Include="..\NServiceBus.AzureFunctions.CodeFixes\NServiceBus.AzureFunctions.CodeFixes.csproj" ReferenceOutputAssembly="false" PrivateAssets="All" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/NServiceBus.AzureFunctions.Common/NServiceBus.AzureFunctions.Common.csproj
+++ b/src/NServiceBus.AzureFunctions.Common/NServiceBus.AzureFunctions.Common.csproj
@@ -13,10 +13,13 @@
 
   <ItemGroup Label="Private dependencies">
     <PackageReference Include="Particular.Packaging" Version="4.5.0" PrivateAssets="All" />
+  </ItemGroup>
+  
+  <ItemGroup Label="Private analyzer dependencies">
     <ProjectReference Include="..\NServiceBus.AzureFunctions.Analyzer\NServiceBus.AzureFunctions.Analyzer.csproj" ReferenceOutputAssembly="false" PrivateAssets="All" />
     <ProjectReference Include="..\NServiceBus.AzureFunctions.CodeFixes\NServiceBus.AzureFunctions.CodeFixes.csproj" ReferenceOutputAssembly="false" PrivateAssets="All" />
   </ItemGroup>
-
+  
   <PropertyGroup>
     <Description>Shared source generator and hosting infrastructure for NServiceBus endpoints hosted in Azure Functions.</Description>
     <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);AddPropsFileToPackage</TargetsForTfmSpecificContentInPackage>

--- a/src/NServiceBus.AzureFunctions.Common/NServiceBus.AzureFunctions.Common.csproj
+++ b/src/NServiceBus.AzureFunctions.Common/NServiceBus.AzureFunctions.Common.csproj
@@ -18,7 +18,7 @@
 
   <ItemGroup Label="Private dependencies">
     <PackageReference Include="Particular.Packaging" Version="4.5.0" PrivateAssets="All" />
-  </ItemGroup
+  </ItemGroup>
 
   <PropertyGroup>
     <Description>Shared source generator and hosting infrastructure for NServiceBus endpoints hosted in Azure Functions.</Description>

--- a/src/NServiceBus.AzureFunctions.Common/NServiceBus.AzureFunctions.Common.csproj
+++ b/src/NServiceBus.AzureFunctions.Common/NServiceBus.AzureFunctions.Common.csproj
@@ -6,6 +6,11 @@
     <AssemblyOriginatorKeyFile>..\NServiceBus.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\NServiceBus.AzureFunctions.Analyzer\NServiceBus.AzureFunctions.Analyzer.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\NServiceBus.AzureFunctions.CodeFixes\NServiceBus.AzureFunctions.CodeFixes.csproj" ReferenceOutputAssembly="false" />
+  </ItemGroup>
+
   <ItemGroup Label="Public dependencies">
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.52.0" />
     <PackageReference Include="NServiceBus" Version="10.2.4" />
@@ -13,13 +18,8 @@
 
   <ItemGroup Label="Private dependencies">
     <PackageReference Include="Particular.Packaging" Version="4.5.0" PrivateAssets="All" />
-  </ItemGroup>
-  
-  <ItemGroup Label="Private analyzer dependencies">
-    <ProjectReference Include="..\NServiceBus.AzureFunctions.Analyzer\NServiceBus.AzureFunctions.Analyzer.csproj" ReferenceOutputAssembly="false" PrivateAssets="All" />
-    <ProjectReference Include="..\NServiceBus.AzureFunctions.CodeFixes\NServiceBus.AzureFunctions.CodeFixes.csproj" ReferenceOutputAssembly="false" PrivateAssets="All" />
-  </ItemGroup>
-  
+  </ItemGroup
+
   <PropertyGroup>
     <Description>Shared source generator and hosting infrastructure for NServiceBus endpoints hosted in Azure Functions.</Description>
     <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);AddPropsFileToPackage</TargetsForTfmSpecificContentInPackage>

--- a/src/NServiceBus.AzureFunctions.Common/NServiceBus.AzureFunctions.Common.csproj
+++ b/src/NServiceBus.AzureFunctions.Common/NServiceBus.AzureFunctions.Common.csproj
@@ -15,6 +15,15 @@
     <PackageReference Include="Particular.Packaging" Version="4.5.0" PrivateAssets="All" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\NServiceBus.AzureFunctions.Analyzer\NServiceBus.AzureFunctions.Analyzer.csproj"
+                      ReferenceOutputAssembly="false"
+                      PrivateAssets="all" />
+    <ProjectReference Include="..\NServiceBus.AzureFunctions.CodeFixes\NServiceBus.AzureFunctions.CodeFixes.csproj"
+                      ReferenceOutputAssembly="false"
+                      PrivateAssets="all" />
+  </ItemGroup>
+
   <PropertyGroup>
     <Description>Shared source generator and hosting infrastructure for NServiceBus endpoints hosted in Azure Functions.</Description>
     <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);AddPropsFileToPackage</TargetsForTfmSpecificContentInPackage>


### PR DESCRIPTION
Without this, the release might fail with

```
Error: /usr/share/dotnet/sdk/10.0.300/NuGet.Build.Tasks.Pack.targets(222,5): error NU5019: File not found: '/home/runner/work/NServiceBus.AzureFunctions/NServiceBus.AzureFunctions/src/NServiceBus.AzureFunctions.Analyzer/bin/Release/netstandard2.0/NServiceBus.AzureFunctions.Analyzer.dll'. [/home/runner/work/NServiceBus.AzureFunctions/NServiceBus.AzureFunctions/src/NServiceBus.AzureFunctions.Common/NServiceBus.AzureFunctions.Common.csproj]
```
This forces the fixer and analyzer to be build before we try to pack them

https://github.com/Particular/NServiceBus.AzureFunctions/actions/runs/26930357041