### PR TITLE
NSBFUNC004 triggers for test projects referencing a project that has functions

### DIFF
--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -33,6 +33,8 @@ dotnet_diagnostic.CA1711.severity = error
 dotnet_diagnostic.CA2007.severity = error
 dotnet_diagnostic.CA2016.severity = error
 
+# ConfigureAwait - not a library
+dotnet_diagnostic.CA2007.severity = none
 
 #### .NET Coding Conventions ####
 

--- a/src/NServiceBus.AzureFunctions.Analyzer/FunctionCompositionGenerator.Parser.cs
+++ b/src/NServiceBus.AzureFunctions.Analyzer/FunctionCompositionGenerator.Parser.cs
@@ -14,10 +14,7 @@ public sealed partial class FunctionCompositionGenerator
         internal static HostProjectSpec ParseHostProject(AnalyzerConfigOptionsProvider provider)
         {
             var options = provider.GlobalOptions;
-            // Host detection intentionally combines both checks:
-            // - FunctionsExecutionModel == isolated identifies Azure Functions worker projects reliably across Functions version changes.
-            // - OutputType == Exe keeps generation scoped to the host executable rather than class libraries.
-            var isHostProject = ProjectDetection.IsExecutableProject(options) && ProjectDetection.IsIsolatedFunctionsProject(options);
+            var isHostProject = ProjectDetection.IsIsolatedFunctionsHostProject(options);
             var effectiveRootNameSpace = ProjectDetection.GetRootNamespace(options);
 
             return new HostProjectSpec(isHostProject, effectiveRootNameSpace);

--- a/src/NServiceBus.AzureFunctions.Analyzer/MissingCompositionCallAnalyzer.cs
+++ b/src/NServiceBus.AzureFunctions.Analyzer/MissingCompositionCallAnalyzer.cs
@@ -24,10 +24,7 @@ public sealed class MissingCompositionCallAnalyzer : DiagnosticAnalyzer
     {
         var globalOptions = context.Options.AnalyzerConfigOptionsProvider.GlobalOptions;
 
-        var isExeOutput = ProjectDetection.IsExecutableProject(context.Compilation, globalOptions);
-        var isAzureFunctionsProject = ProjectDetection.IsIsolatedFunctionsProject(context.Compilation, globalOptions);
-
-        if (!isExeOutput || !isAzureFunctionsProject)
+        if (!ProjectDetection.IsIsolatedFunctionsHostProject(globalOptions))
         {
             return;
         }

--- a/src/NServiceBus.AzureFunctions.Analyzer/ProjectDetection.cs
+++ b/src/NServiceBus.AzureFunctions.Analyzer/ProjectDetection.cs
@@ -1,9 +1,7 @@
 namespace NServiceBus.AzureFunctions.Analyzer;
 
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using static BuildPropertyNames;
-using static KnownTypeNames;
 
 static class ProjectDetection
 {

--- a/src/NServiceBus.AzureFunctions.Analyzer/ProjectDetection.cs
+++ b/src/NServiceBus.AzureFunctions.Analyzer/ProjectDetection.cs
@@ -5,19 +5,20 @@ using static BuildPropertyNames;
 
 static class ProjectDetection
 {
-    const string IsolatedExecutionModel = "isolated";
-
-    // We intentionally key on FunctionsExecutionModel instead of AzureFunctionsVersion so detection
-    // stays stable if the Functions SDK updates version labels (for example, v4 -> v5).
-    public static bool IsIsolatedFunctionsProject(AnalyzerConfigOptions options)
-        => options.TryGetValue(FunctionsExecutionModel, out var executionModel)
-           && string.Equals(executionModel, IsolatedExecutionModel, StringComparison.OrdinalIgnoreCase);
-
+    // FunctionHost detection intentionally combines both checks:
+    // - OutputType == Exe keeps generation scoped to the host executable rather than class libraries.
+    // - FunctionsExecutionModel == isolated identifies Azure Functions worker projects reliably across Functions version changes.
     public static bool IsIsolatedFunctionsHostProject(AnalyzerConfigOptions options)
         => IsExecutableProject(options)
            && IsIsolatedFunctionsProject(options);
 
-    public static bool IsExecutableProject(AnalyzerConfigOptions options)
+    // We intentionally key on FunctionsExecutionModel instead of AzureFunctionsVersion so detection
+    // stays stable if the Functions SDK updates version labels (for example, v4 -> v5).
+    static bool IsIsolatedFunctionsProject(AnalyzerConfigOptions options)
+        => options.TryGetValue(FunctionsExecutionModel, out var executionModel)
+           && string.Equals(executionModel, IsolatedExecutionModel, StringComparison.OrdinalIgnoreCase);
+
+    static bool IsExecutableProject(AnalyzerConfigOptions options)
         => options.TryGetValue(OutputType, out var outputType)
            && string.Equals(outputType, "Exe", StringComparison.OrdinalIgnoreCase);
 
@@ -31,4 +32,6 @@ static class ProjectDetection
 
         return rootNamespace;
     }
+
+    const string IsolatedExecutionModel = "isolated";
 }

--- a/src/NServiceBus.AzureFunctions.Analyzer/ProjectDetection.cs
+++ b/src/NServiceBus.AzureFunctions.Analyzer/ProjectDetection.cs
@@ -15,19 +15,13 @@ static class ProjectDetection
         => options.TryGetValue(FunctionsExecutionModel, out var executionModel)
            && string.Equals(executionModel, IsolatedExecutionModel, StringComparison.OrdinalIgnoreCase);
 
-    // In production, FunctionsExecutionModel is the source of truth. The symbol fallback exists only
-    // because SourceGeneratorTest currently does not flow WithProperty(...) values to analyzers.
-    // Keep this fallback until analyzer config options are propagated in Particular.AnalyzerTesting.
-    public static bool IsIsolatedFunctionsProject(Compilation compilation, AnalyzerConfigOptions options)
-        => IsIsolatedFunctionsProject(options) || compilation.GetTypeByMetadataName(FunctionAttribute) is not null;
+    public static bool IsIsolatedFunctionsHostProject(AnalyzerConfigOptions options)
+        => IsExecutableProject(options)
+           && IsIsolatedFunctionsProject(options);
 
     public static bool IsExecutableProject(AnalyzerConfigOptions options)
         => options.TryGetValue(OutputType, out var outputType)
            && string.Equals(outputType, "Exe", StringComparison.OrdinalIgnoreCase);
-
-    public static bool IsExecutableProject(Compilation compilation, AnalyzerConfigOptions options)
-        => IsExecutableProject(options)
-           || compilation.Options.OutputKind is OutputKind.ConsoleApplication or OutputKind.WindowsApplication;
 
     public static string? GetRootNamespace(AnalyzerConfigOptions options)
     {

--- a/src/Tests.Analyzers/MissingCompositionCallAnalyzerTests.cs
+++ b/src/Tests.Analyzers/MissingCompositionCallAnalyzerTests.cs
@@ -1,7 +1,13 @@
 namespace NServiceBus.AzureFunctions.Analyzers.Tests;
 
+using System.IO;
+using System.Linq;
+using Microsoft.Azure.Functions.Worker;
 using NServiceBus.AzureFunctions.Analyzer;
+using NServiceBus.AzureFunctions.Analyzer.Utility;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Diagnostics;
 using NUnit.Framework;
 using Particular.AnalyzerTesting;
 
@@ -78,6 +84,33 @@ public class MissingCompositionCallAnalyzerTests
         Assert.That(diagnostics, Has.None.Matches<Diagnostic>(d => d.Id == DiagnosticIds.MissingAddNServiceBusFunctionsCall));
     }
 
+    [Test]
+    public async Task DoesNotReportDiagnosticForNonFunctionsProjectReferencingFunctionsApp()
+    {
+        var functionsAppReference = BuildFunctionsAppReference();
+
+        var compilation = CSharpCompilation.Create(
+            assemblyName: "Tests",
+            syntaxTrees:
+            [
+                CSharpSyntaxTree.ParseText(
+                    "public class Tests { }",
+                    path: "Tests.cs")
+            ],
+            references:
+            [
+                MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+                MetadataReference.CreateFromFile(typeof(FunctionAttribute).Assembly.Location),
+                functionsAppReference
+            ],
+            options: new CSharpCompilationOptions(OutputKind.ConsoleApplication));
+
+        var analyzer = new MissingCompositionCallAnalyzer();
+        var diagnostics = await compilation.WithAnalyzers([analyzer]).GetAnalyzerDiagnosticsAsync();
+
+        Assert.That(diagnostics, Has.None.Matches<Diagnostic>(d => d.Id == DiagnosticIds.MissingAddNServiceBusFunctionsCall));
+    }
+
     static SourceGeneratorTest CreateSourceGeneratorAnalyzerTest() =>
         SourceGeneratorTest.ForIncrementalGenerator<FunctionEndpointGenerator>()
             .WithIncrementalGenerator<SendOnlyEndpointGenerator>()
@@ -88,4 +121,41 @@ public class MissingCompositionCallAnalyzerTests
             .WithProperty("build_property.FunctionsExecutionModel", "isolated")
             .WithProperty("build_property.RootNamespace", "My.FunctionApp")
             .SuppressCompilationErrors();
+
+    static MetadataReference BuildFunctionsAppReference()
+    {
+        const string assemblyName = "ReferencedFunctionsApp";
+
+        var preliminaryCompilation = CSharpCompilation.Create(
+            assemblyName: assemblyName,
+            references:
+            [
+                MetadataReference.CreateFromFile(typeof(object).Assembly.Location)
+            ],
+            options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        var generatedTypeName = $"GeneratedFunctionRegistrations_{assemblyName}_{NonCryptographicHash.GetHash(preliminaryCompilation.Assembly.Identity.GetDisplayName()):x16}";
+
+        var compilation = CSharpCompilation.Create(
+            assemblyName: "ReferencedFunctionsApp",
+            syntaxTrees:
+            [
+                CSharpSyntaxTree.ParseText(
+                    $"namespace NServiceBus.Generated; public static class {generatedTypeName} {{ }}",
+                    path: "Generated.cs")
+            ],
+            references:
+            [
+                MetadataReference.CreateFromFile(typeof(object).Assembly.Location)
+            ],
+            options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        using var stream = new MemoryStream();
+        var emitResult = compilation.Emit(stream);
+
+        Assert.That(emitResult.Success, Is.True, string.Join(System.Environment.NewLine, emitResult.Diagnostics.Select(static d => d.ToString())));
+
+        stream.Position = 0;
+        return MetadataReference.CreateFromImage(stream.ToArray());
+    }
 }


### PR DESCRIPTION
root cause: Test projects are treated like exes

```
$ dotnet msbuild "src/InternalAutomation.Tests/InternalAutomation.Tests.csproj" -getProperty:OutputType
Exe
```

due to

```
- Microsoft.NET.Test.Sdk overrides the project's output type for .NET test projects.
- In ~/.nuget/packages/microsoft.net.test.sdk/18.5.1/build/net8.0/Microsoft.NET.Test.Sdk.targets:21:
<OutputType Condition="'$(UseWinUI)' != 'true' AND '$(UseUwpTools)' != 'true'">Exe</OutputType>
```
