### PR TITLE
Add AOT compatibility to Azure Functions project files

### DIFF
--- a/src/IntegrationTest.Billing/IntegrationTest.Billing.csproj
+++ b/src/IntegrationTest.Billing/IntegrationTest.Billing.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
+    <IsAotCompatible>true</IsAotCompatible>
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
     <CompilerGeneratedFilesOutputPath>$(BaseIntermediateOutputPath)\GeneratedFiles</CompilerGeneratedFilesOutputPath>
   </PropertyGroup>

--- a/src/IntegrationTest.Contracts/IntegrationTest.Contracts.csproj
+++ b/src/IntegrationTest.Contracts/IntegrationTest.Contracts.csproj
@@ -4,6 +4,7 @@
         <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
+        <IsAotCompatible>true</IsAotCompatible>
     </PropertyGroup>
 
 </Project>

--- a/src/IntegrationTest.Sales/IntegrationTest.Sales.csproj
+++ b/src/IntegrationTest.Sales/IntegrationTest.Sales.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
+    <IsAotCompatible>true</IsAotCompatible>
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
     <CompilerGeneratedFilesOutputPath>$(BaseIntermediateOutputPath)\GeneratedFiles</CompilerGeneratedFilesOutputPath>
   </PropertyGroup>

--- a/src/IntegrationTest.Shared/IntegrationTest.Shared.csproj
+++ b/src/IntegrationTest.Shared/IntegrationTest.Shared.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
+    <IsAotCompatible>true</IsAotCompatible>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/IntegrationTest.Shipping/IntegrationTest.Shipping.csproj
+++ b/src/IntegrationTest.Shipping/IntegrationTest.Shipping.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
+    <IsAotCompatible>true</IsAotCompatible>
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
     <CompilerGeneratedFilesOutputPath>$(BaseIntermediateOutputPath)\GeneratedFiles</CompilerGeneratedFilesOutputPath>
   </PropertyGroup>

--- a/src/IntegrationTestApp/IntegrationTestApp.csproj
+++ b/src/IntegrationTestApp/IntegrationTestApp.csproj
@@ -5,6 +5,7 @@
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
+    <IsAotCompatible>true</IsAotCompatible>
     <OutputType>Exe</OutputType>
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
     <CompilerGeneratedFilesOutputPath>$(BaseIntermediateOutputPath)\GeneratedFiles</CompilerGeneratedFilesOutputPath>

--- a/src/NServiceBus.AzureFunctions.AzureServiceBus/NServiceBus.AzureFunctions.AzureServiceBus.csproj
+++ b/src/NServiceBus.AzureFunctions.AzureServiceBus/NServiceBus.AzureFunctions.AzureServiceBus.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
+    <IsAotCompatible>true</IsAotCompatible>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\NServiceBus.snk</AssemblyOriginatorKeyFile>
     <Description>Azure Functions hosting for NServiceBus endpoints with Azure Serivce Bus triggers</Description>

--- a/src/NServiceBus.AzureFunctions.Common/NServiceBus.AzureFunctions.Common.csproj
+++ b/src/NServiceBus.AzureFunctions.Common/NServiceBus.AzureFunctions.Common.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
+    <IsAotCompatible>true</IsAotCompatible>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\NServiceBus.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>


### PR DESCRIPTION
Given the library itself uses only [compatible APIs by default I think we can flag it as AOT compatible, which enforces all the necessary analyzers](https://learn.microsoft.com/en-us/dotnet/core/deploying/native-aot/?tabs=windows%2Cnet8#aot-compatibility-analyzers).

Alternative: IsTrimmable but I think that is slightly too weak.