### PR TITLE
Fix configure method discovery to accept more flexible naming conventions

### DIFF
--- a/src/NServiceBus.AzureFunctions.Analyzer/FunctionEndpointGenerator.Parser.cs
+++ b/src/NServiceBus.AzureFunctions.Analyzer/FunctionEndpointGenerator.Parser.cs
@@ -469,7 +469,7 @@ public sealed partial class FunctionEndpointGenerator
             IMethodSymbol? configureMethod = null;
             foreach (var member in functionClassType.GetMembers())
             {
-                if (member is IMethodSymbol method && method.Name == configureMethodName)
+                if (member is IMethodSymbol method && string.Equals(method.Name, configureMethodName, StringComparison.OrdinalIgnoreCase))
                 {
                     if (configureMethod is not null)
                     {

--- a/src/NServiceBus.AzureFunctions.Analyzer/FunctionEndpointGenerator.Parser.cs
+++ b/src/NServiceBus.AzureFunctions.Analyzer/FunctionEndpointGenerator.Parser.cs
@@ -464,16 +464,17 @@ public sealed partial class FunctionEndpointGenerator
 
         static ConfigureMethodSpec? GetConfigureMethodSpec(INamedTypeSymbol functionClassType, string endpointName, FunctionEndpointGeneratorKnownTypes knownTypes, List<Diagnostic> diagnostics)
         {
-            var configureMethodName = KnownTypeNames.ConfigureMethodName(endpointName);
+            var normalizedEndpointName = KnownTypeNames.Normalize(endpointName);
 
             IMethodSymbol? configureMethod = null;
             foreach (var member in functionClassType.GetMembers())
             {
-                if (member is IMethodSymbol method && string.Equals(method.Name, configureMethodName, StringComparison.OrdinalIgnoreCase))
+                if (member is IMethodSymbol method && KnownTypeNames.IsConfigureMethodFor(method.Name, normalizedEndpointName))
                 {
                     if (configureMethod is not null)
                     {
-                        diagnostics.Add(functionClassType.CreateDiagnostic(DiagnosticIds.MultipleConfigureMethodsDescriptor, configureMethodName, functionClassType.Name));
+                        var suggestedName = KnownTypeNames.ConfigureMethodName(endpointName);
+                        diagnostics.Add(functionClassType.CreateDiagnostic(DiagnosticIds.MultipleConfigureMethodsDescriptor, suggestedName, functionClassType.Name));
                         return null;
                     }
 

--- a/src/NServiceBus.AzureFunctions.Analyzer/KnownTypeNames.cs
+++ b/src/NServiceBus.AzureFunctions.Analyzer/KnownTypeNames.cs
@@ -2,6 +2,8 @@ namespace NServiceBus.AzureFunctions.Analyzer;
 
 static class KnownTypeNames
 {
+    const string ConfigurePrefix = "Configure";
+
     public static string ConfigureMethodName(string endpointName)
     {
         if (endpointName == null)
@@ -9,12 +11,28 @@ static class KnownTypeNames
             throw new ArgumentNullException(nameof(endpointName));
         }
 
-        // Unfortunately, we cannot use SearchValues and ReplaceAny because we are stuck with NetStandard2.0 and those APIs are only available in .NET.
-        // Pooling is not helpful here because it would make things slower
-        var buffer = new char[endpointName.Length];
+        var normalized = Normalize(endpointName);
+        if (normalized.Length == 0)
+        {
+            throw new ArgumentException(
+                $"Cannot generate a valid C# configuration method name from endpoint name '{endpointName}' because it does not contain any ASCII letters or digits.",
+                nameof(endpointName));
+        }
+
+        return $"{ConfigurePrefix}{normalized}";
+    }
+
+    public static string Normalize(string name)
+    {
+        if (name == null)
+        {
+            return string.Empty;
+        }
+
+        var buffer = new char[name.Length];
         var count = 0;
 
-        foreach (var c in endpointName)
+        foreach (var c in name)
         {
             if (c is (>= 'A' and <= 'Z') or (>= 'a' and <= 'z') or (>= '0' and <= '9'))
             {
@@ -22,14 +40,26 @@ static class KnownTypeNames
             }
         }
 
-        if (count == 0)
+        return count == 0 ? string.Empty : count == name.Length ? name : new string(buffer, 0, count);
+    }
+
+    public static bool IsConfigureMethodFor(string methodName, string normalizedEndpointName)
+    {
+        if (!methodName.StartsWith(ConfigurePrefix, StringComparison.OrdinalIgnoreCase))
         {
-            throw new ArgumentException(
-                $"Cannot generate a valid C# configuration method name from endpoint name '{endpointName}' because it does not contain any ASCII letters, digits, or underscores.",
-                nameof(endpointName));
+            return false;
         }
 
-        return count == endpointName.Length ? $"Configure{endpointName}" : $"Configure{new string(buffer, 0, count)}";
+        if (methodName.Length == ConfigurePrefix.Length)
+        {
+            return false;
+        }
+
+        var suffix = methodName.Substring(ConfigurePrefix.Length);
+        var normalizedSuffix = Normalize(suffix);
+
+        return normalizedSuffix.Length > 0
+            && string.Equals(normalizedSuffix, normalizedEndpointName, StringComparison.OrdinalIgnoreCase);
     }
 
     public const string GeneratedCompositionNamespace = "NServiceBus";

--- a/src/NServiceBus.AzureFunctions.Analyzer/KnownTypeNames.cs
+++ b/src/NServiceBus.AzureFunctions.Analyzer/KnownTypeNames.cs
@@ -34,7 +34,7 @@ static class KnownTypeNames
 
         foreach (var c in name)
         {
-            if (c is (>= 'A' and <= 'Z') or (>= 'a' and <= 'z') or (>= '0' and <= '9'))
+            if (char.IsLetterOrDigit(c))
             {
                 buffer[count++] = c;
             }

--- a/src/NServiceBus.AzureFunctions.Analyzer/KnownTypeNames.cs
+++ b/src/NServiceBus.AzureFunctions.Analyzer/KnownTypeNames.cs
@@ -2,7 +2,11 @@ namespace NServiceBus.AzureFunctions.Analyzer;
 
 static class KnownTypeNames
 {
-    public static string ConfigureMethodName(string endpointName) => $"Configure{endpointName}";
+    public static string ConfigureMethodName(string endpointName)
+    {
+        var sanitized = new string([.. endpointName.Where(char.IsLetterOrDigit)]);
+        return $"Configure{(sanitized.Length > 0 ? sanitized : "Endpoint")}";
+    }
     public const string GeneratedCompositionNamespace = "NServiceBus";
     public const string GeneratedFunctionsCompositionFullName = "NServiceBus.NServiceBusGeneratedFunctionsComposition";
     public const string FunctionAttribute = "Microsoft.Azure.Functions.Worker.FunctionAttribute";

--- a/src/NServiceBus.AzureFunctions.Analyzer/KnownTypeNames.cs
+++ b/src/NServiceBus.AzureFunctions.Analyzer/KnownTypeNames.cs
@@ -16,7 +16,7 @@ static class KnownTypeNames
 
         foreach (var c in endpointName)
         {
-            if (c is (>= 'A' and <= 'Z') or (>= 'a' and <= 'z') or (>= '0' and <= '9') or '_')
+            if (c is (>= 'A' and <= 'Z') or (>= 'a' and <= 'z') or (>= '0' and <= '9'))
             {
                 buffer[count++] = c;
             }

--- a/src/NServiceBus.AzureFunctions.Analyzer/KnownTypeNames.cs
+++ b/src/NServiceBus.AzureFunctions.Analyzer/KnownTypeNames.cs
@@ -4,10 +4,34 @@ static class KnownTypeNames
 {
     public static string ConfigureMethodName(string endpointName)
     {
-        var sanitized = new string([.. endpointName.Where(char.IsLetterOrDigit)]);
+        if (endpointName == null)
+        {
+            throw new ArgumentNullException(nameof(endpointName));
+        }
 
-        return sanitized.Length == 0 ? throw new ArgumentException($"Invalid {endpointName}") : $"Configure{sanitized}";
+        // Unfortunately, we cannot use SearchValues and ReplaceAny because we are stuck with NetStandard2.0 and those APIs are only available in .NET.
+        // Pooling is not helpful here because it would make things slower
+        var buffer = new char[endpointName.Length];
+        var count = 0;
+
+        foreach (var c in endpointName)
+        {
+            if (c is (>= 'A' and <= 'Z') or (>= 'a' and <= 'z') or (>= '0' and <= '9') or '_')
+            {
+                buffer[count++] = c;
+            }
+        }
+
+        if (count == 0)
+        {
+            throw new ArgumentException(
+                $"Cannot generate a valid C# configuration method name from endpoint name '{endpointName}' because it does not contain any ASCII letters, digits, or underscores.",
+                nameof(endpointName));
+        }
+
+        return count == endpointName.Length ? $"Configure{endpointName}" : $"Configure{new string(buffer, 0, count)}";
     }
+
     public const string GeneratedCompositionNamespace = "NServiceBus";
     public const string GeneratedFunctionsCompositionFullName = "NServiceBus.NServiceBusGeneratedFunctionsComposition";
     public const string FunctionAttribute = "Microsoft.Azure.Functions.Worker.FunctionAttribute";

--- a/src/NServiceBus.AzureFunctions.Analyzer/KnownTypeNames.cs
+++ b/src/NServiceBus.AzureFunctions.Analyzer/KnownTypeNames.cs
@@ -5,7 +5,8 @@ static class KnownTypeNames
     public static string ConfigureMethodName(string endpointName)
     {
         var sanitized = new string([.. endpointName.Where(char.IsLetterOrDigit)]);
-        return $"Configure{(sanitized.Length > 0 ? sanitized : "Endpoint")}";
+
+        return sanitized.Length == 0 ? throw new ArgumentException($"Invalid {endpointName}") : $"Configure{sanitized}";
     }
     public const string GeneratedCompositionNamespace = "NServiceBus";
     public const string GeneratedFunctionsCompositionFullName = "NServiceBus.NServiceBusGeneratedFunctionsComposition";

--- a/src/NServiceBus.AzureFunctions.Analyzer/SendOnlyEndpointGenerator.Parser.cs
+++ b/src/NServiceBus.AzureFunctions.Analyzer/SendOnlyEndpointGenerator.Parser.cs
@@ -59,10 +59,11 @@ public sealed partial class SendOnlyEndpointGenerator
                 problems.Add("method must be static");
             }
 
-            var expectedMethodName = KnownTypeNames.ConfigureMethodName(endpointName);
-            if (!string.Equals(method.Name, expectedMethodName, StringComparison.OrdinalIgnoreCase))
+            var normalizedEndpointName = KnownTypeNames.Normalize(endpointName);
+            if (!KnownTypeNames.IsConfigureMethodFor(method.Name, normalizedEndpointName))
             {
-                problems.Add($"method name must be '{expectedMethodName}'");
+                var expectedMethodName = KnownTypeNames.ConfigureMethodName(endpointName);
+                problems.Add($"method name must follow the 'Configure{{EndpointName}}' convention matching '{expectedMethodName}'");
             }
 
             var resolution = ConfigureMethodResolver.Resolve(method, knownTypes.EndpointConfiguration, knownTypes.DelegateType);

--- a/src/Tests.Analyzers/FunctionEndpointGeneratorTests.cs
+++ b/src/Tests.Analyzers/FunctionEndpointGeneratorTests.cs
@@ -16,6 +16,44 @@ public class FunctionEndpointGeneratorTests
             .Approve()
             .AssertRunsAreEqual();
 
+    [TestCaseSource(typeof(TestSources), nameof(TestSources.EndpointNameSanitizationCases))]
+    public void GeneratesFunctionEndpoint(string endpointName, string configureMethodName)
+    {
+        var source = $$"""
+        using System.Threading;
+        using System.Threading.Tasks;
+        using Azure.Messaging.ServiceBus;
+        using Microsoft.Azure.Functions.Worker;
+        using Microsoft.Extensions.Configuration;
+        using Microsoft.Extensions.Hosting;
+        using NServiceBus;
+
+        namespace Demo;
+
+        public partial class Functions
+        {
+            [NServiceBusFunction]
+            [Function("{{endpointName}}")]
+            public partial Task Run(
+                [ServiceBusTrigger("sales-queue", Connection = "AzureServiceBus", AutoCompleteMessages = false)] ServiceBusReceivedMessage message,
+                ServiceBusMessageActions messageActions,
+                FunctionContext context,
+                CancellationToken cancellationToken);
+
+            public static void {{configureMethodName}}(
+                EndpointConfiguration endpointConfiguration,
+                IConfigurationManager iconfigurationmanager,
+                IHostEnvironment ihostenvironment)
+            {
+            }
+        }
+        """;
+
+        SourceGeneratorTest.ForIncrementalGenerator<FunctionEndpointGenerator>()
+            .WithSource(source)
+            .Run();
+    }
+
     [Test]
     public void GeneratesFunctionEndpointInGlobalNamespace() =>
         SourceGeneratorTest.ForIncrementalGenerator<FunctionEndpointGenerator>()
@@ -625,37 +663,6 @@ public class FunctionEndpointGeneratorTests
     }
 
     #endregion
-
-    [TestCaseSource(typeof(TestSources), nameof(TestSources.EndpointNameSanitizationCases))]
-    public void MatchesConfigureMethod(string endpointName, string configureMethodName)
-    {
-        var classBody = $$"""
-            public partial class Functions
-            {
-                [NServiceBusFunction]
-                [Function("{{endpointName}}")]
-                public partial Task Run(
-                    [TestTrigger("sales-queue", ConnSetting = "StorageConn", AutoCompleteMessages = false)] string message,
-                    FunctionContext context,
-                    CancellationToken cancellationToken);
-
-                public static void {{configureMethodName}}(
-                    EndpointConfiguration endpointConfiguration)
-                {
-                }
-            }
-            """;
-
-        var source = NoMessageActionsSource(classBody);
-        var result = SourceGeneratorTest.ForIncrementalGenerator<NoMessageActionsGenerator>()
-            .WithSource(source)
-            .SuppressCompilationErrors()
-            .SuppressDiagnosticErrors()
-            .Run();
-
-        var diagnostics = result.GeneratorDiagnostics;
-        Assert.That(diagnostics, Has.None.Matches<Diagnostic>(d => d.Id == DiagnosticIds.InvalidFunctionMethod));
-    }
 
     #region Helpers
 

--- a/src/Tests.Analyzers/FunctionEndpointGeneratorTests.cs
+++ b/src/Tests.Analyzers/FunctionEndpointGeneratorTests.cs
@@ -16,8 +16,15 @@ public class FunctionEndpointGeneratorTests
             .Approve()
             .AssertRunsAreEqual();
 
-    [TestCaseSource(typeof(TestSources), nameof(TestSources.EndpointNameSanitizationCases))]
-    public void SanitizesConfigureMethod(string endpointName, string configureMethodName)
+    [TestCase("my-endpoint", "Configuremyendpoint")]
+    [TestCase("process.order", "Configureprocessorder")]
+    [TestCase("my_endpoint", "Configuremyendpoint")]
+    [TestCase("ProcessOrder", "configureprocessorder")]
+    [TestCase("my-endpoint", "ConfigureMy_Endpoint")]
+    [TestCase("my-endpoint", "Configuremy_endpoint")]
+    [TestCase("ProcessOrder", "CONFIGUREprocessORDER")]
+    [TestCase("ProcessOrder", "configure_process_order")]
+    public void FlexibleConfigureMethodNameMatches(string endpointName, string configureMethodName)
     {
         var source = $$"""
         using System.Threading;
@@ -690,6 +697,8 @@ public class FunctionEndpointGeneratorTests
             using Microsoft.Azure.Functions.Worker;
             using NServiceBus;
 
+            #nullable enable
+
             namespace Demo.Testing;
 
             [System.AttributeUsage(System.AttributeTargets.Parameter)]
@@ -703,6 +712,11 @@ public class FunctionEndpointGeneratorTests
             public static class TestFunctionManifestRegistration
             {
                 public static void Register(global::Microsoft.Azure.Functions.Worker.Builder.FunctionsApplicationBuilder _, global::NServiceBus.FunctionManifest __) { }
+            }
+
+            public class TestProcessor
+            {
+                public Task Process(string message, FunctionContext context, CancellationToken cancellationToken) => Task.CompletedTask;
             }
 
             {{classBody}}

--- a/src/Tests.Analyzers/FunctionEndpointGeneratorTests.cs
+++ b/src/Tests.Analyzers/FunctionEndpointGeneratorTests.cs
@@ -17,7 +17,7 @@ public class FunctionEndpointGeneratorTests
             .AssertRunsAreEqual();
 
     [TestCaseSource(typeof(TestSources), nameof(TestSources.EndpointNameSanitizationCases))]
-    public void GeneratesFunctionEndpoint(string endpointName, string configureMethodName)
+    public void SanitizesConfigureMethod(string endpointName, string configureMethodName)
     {
         var source = $$"""
         using System.Threading;

--- a/src/Tests.Analyzers/FunctionEndpointGeneratorTests.cs
+++ b/src/Tests.Analyzers/FunctionEndpointGeneratorTests.cs
@@ -35,15 +35,12 @@ public class FunctionEndpointGeneratorTests
             [NServiceBusFunction]
             [Function("{{endpointName}}")]
             public partial Task Run(
-                [ServiceBusTrigger("sales-queue", Connection = "AzureServiceBus", AutoCompleteMessages = false)] ServiceBusReceivedMessage message,
+                [ServiceBusTrigger("sales-queue", AutoCompleteMessages = false)] ServiceBusReceivedMessage message,
                 ServiceBusMessageActions messageActions,
                 FunctionContext context,
                 CancellationToken cancellationToken);
 
-            public static void {{configureMethodName}}(
-                EndpointConfiguration endpointConfiguration,
-                IConfigurationManager iconfigurationmanager,
-                IHostEnvironment ihostenvironment)
+            public static void {{configureMethodName}}(EndpointConfiguration endpointConfiguration)
             {
             }
         }

--- a/src/Tests.Analyzers/FunctionEndpointGeneratorTests.cs
+++ b/src/Tests.Analyzers/FunctionEndpointGeneratorTests.cs
@@ -24,6 +24,7 @@ public class FunctionEndpointGeneratorTests
     [TestCase("my-endpoint", "Configuremy_endpoint")]
     [TestCase("ProcessOrder", "CONFIGUREprocessORDER")]
     [TestCase("ProcessOrder", "configure_process_order")]
+    [TestCase("Lösung-Endpoint", "ConfigureLösungEndpoint")]
     public void FlexibleConfigureMethodNameMatches(string endpointName, string configureMethodName)
     {
         var source = $$"""

--- a/src/Tests.Analyzers/FunctionEndpointGeneratorTests.cs
+++ b/src/Tests.Analyzers/FunctionEndpointGeneratorTests.cs
@@ -649,6 +649,8 @@ public class FunctionEndpointGeneratorTests
         var source = NoMessageActionsSource(classBody);
         var result = SourceGeneratorTest.ForIncrementalGenerator<NoMessageActionsGenerator>()
             .WithSource(source)
+            .SuppressCompilationErrors()
+            .SuppressDiagnosticErrors()
             .Run();
 
         var diagnostics = result.GeneratorDiagnostics;

--- a/src/Tests.Analyzers/FunctionEndpointGeneratorTests.cs
+++ b/src/Tests.Analyzers/FunctionEndpointGeneratorTests.cs
@@ -626,6 +626,35 @@ public class FunctionEndpointGeneratorTests
 
     #endregion
 
+    [TestCaseSource(typeof(TestSources), nameof(TestSources.EndpointNameSanitizationCases))]
+    public void MatchesConfigureMethod(string endpointName, string configureMethodName)
+    {
+        var classBody = $$"""
+            public partial class Functions
+            {
+                [NServiceBusFunction]
+                [Function("{{endpointName}}")]
+                public partial Task Run(
+                    [TestTrigger("sales-queue", ConnSetting = "StorageConn", AutoCompleteMessages = false)] string message,
+                    FunctionContext context,
+                    CancellationToken cancellationToken);
+
+                public static void {{configureMethodName}}(
+                    EndpointConfiguration endpointConfiguration)
+                {
+                }
+            }
+            """;
+
+        var source = NoMessageActionsSource(classBody);
+        var result = SourceGeneratorTest.ForIncrementalGenerator<NoMessageActionsGenerator>()
+            .WithSource(source)
+            .Run();
+
+        var diagnostics = result.GeneratorDiagnostics;
+        Assert.That(diagnostics, Has.None.Matches<Diagnostic>(d => d.Id == DiagnosticIds.InvalidFunctionMethod));
+    }
+
     #region Helpers
 
     static Diagnostic GetInvalidFunctionMethodDiagnostic<TGenerator>(string source) where TGenerator : IIncrementalGenerator, new()

--- a/src/Tests.Analyzers/SendOnlyEndpointGeneratorTests.cs
+++ b/src/Tests.Analyzers/SendOnlyEndpointGeneratorTests.cs
@@ -215,7 +215,7 @@ public class SendOnlyEndpointGeneratorTests
     }
 
     [TestCaseSource(typeof(TestSources), nameof(TestSources.EndpointNameSanitizationCases))]
-    public void MatchesConfigureMethod(string endpointName, string configureMethodName)
+    public void SanitizesConfigureMethod(string endpointName, string configureMethodName)
     {
         var source = $$"""
             using NServiceBus;

--- a/src/Tests.Analyzers/SendOnlyEndpointGeneratorTests.cs
+++ b/src/Tests.Analyzers/SendOnlyEndpointGeneratorTests.cs
@@ -214,6 +214,31 @@ public class SendOnlyEndpointGeneratorTests
         Assert.That(message, Does.Contain("first parameter must be EndpointConfiguration"));
     }
 
+    [TestCaseSource(typeof(TestSources), nameof(TestSources.EndpointNameSanitizationCases))]
+    public void MatchesConfigureMethod(string endpointName, string configureMethodName)
+    {
+        var source = $$"""
+            using NServiceBus;
+
+            namespace Demo;
+
+            public static class ClientEndpoint
+            {
+                [NServiceBusSendOnlyFunction("{{endpointName}}")]
+                public static void {{configureMethodName}}(EndpointConfiguration endpointConfiguration)
+                {
+                }
+            }
+            """;
+
+        var result = SourceGeneratorTest.ForIncrementalGenerator<SendOnlyEndpointGenerator>()
+            .WithSource(source)
+            .Run();
+
+        var diagnostics = result.GeneratorDiagnostics;
+        Assert.That(diagnostics, Has.None.Matches<Diagnostic>(d => d.Id == DiagnosticIds.InvalidSendOnlyEndpointMethod));
+    }
+
     #region Helpers
 
     static Diagnostic GetInvalidSendOnlyEndpointMethodDiagnostic(string source)

--- a/src/Tests.Analyzers/SendOnlyEndpointGeneratorTests.cs
+++ b/src/Tests.Analyzers/SendOnlyEndpointGeneratorTests.cs
@@ -231,12 +231,9 @@ public class SendOnlyEndpointGeneratorTests
             }
             """;
 
-        var result = SourceGeneratorTest.ForIncrementalGenerator<SendOnlyEndpointGenerator>()
+        SourceGeneratorTest.ForIncrementalGenerator<SendOnlyEndpointGenerator>()
             .WithSource(source)
             .Run();
-
-        var diagnostics = result.GeneratorDiagnostics;
-        Assert.That(diagnostics, Has.None.Matches<Diagnostic>(d => d.Id == DiagnosticIds.InvalidSendOnlyEndpointMethod));
     }
 
     #region Helpers

--- a/src/Tests.Analyzers/SendOnlyEndpointGeneratorTests.cs
+++ b/src/Tests.Analyzers/SendOnlyEndpointGeneratorTests.cs
@@ -222,6 +222,7 @@ public class SendOnlyEndpointGeneratorTests
     [TestCase("my-endpoint", "Configuremy_endpoint")]
     [TestCase("ProcessOrder", "CONFIGUREprocessORDER")]
     [TestCase("ProcessOrder", "configure_process_order")]
+    [TestCase("Lösung-Endpoint", "ConfigureLösungEndpoint")]
     public void FlexibleConfigureMethodNameMatches(string endpointName, string configureMethodName)
     {
         var source = $$"""

--- a/src/Tests.Analyzers/SendOnlyEndpointGeneratorTests.cs
+++ b/src/Tests.Analyzers/SendOnlyEndpointGeneratorTests.cs
@@ -128,7 +128,7 @@ public class SendOnlyEndpointGeneratorTests
             }
             """);
 
-        Assert.That(diagnostic.GetMessage(), Does.Contain("method name must be 'Configureclient'"));
+        Assert.That(diagnostic.GetMessage(), Does.Contain("method name must follow the 'Configure{EndpointName}' convention matching 'Configureclient'"));
     }
 
     [Test]
@@ -210,12 +210,19 @@ public class SendOnlyEndpointGeneratorTests
 
         var message = diagnostic.GetMessage();
         Assert.That(message, Does.Contain("method must be static"));
-        Assert.That(message, Does.Contain("method name must be 'Configureclient'"));
+        Assert.That(message, Does.Contain("method name must follow the 'Configure{EndpointName}' convention matching 'Configureclient'"));
         Assert.That(message, Does.Contain("first parameter must be EndpointConfiguration"));
     }
 
-    [TestCaseSource(typeof(TestSources), nameof(TestSources.EndpointNameSanitizationCases))]
-    public void SanitizesConfigureMethod(string endpointName, string configureMethodName)
+    [TestCase("my-endpoint", "Configuremyendpoint")]
+    [TestCase("process.order", "Configureprocessorder")]
+    [TestCase("my_endpoint", "Configuremyendpoint")]
+    [TestCase("ProcessOrder", "configureprocessorder")]
+    [TestCase("my-endpoint", "ConfigureMy_Endpoint")]
+    [TestCase("my-endpoint", "Configuremy_endpoint")]
+    [TestCase("ProcessOrder", "CONFIGUREprocessORDER")]
+    [TestCase("ProcessOrder", "configure_process_order")]
+    public void FlexibleConfigureMethodNameMatches(string endpointName, string configureMethodName)
     {
         var source = $$"""
             using NServiceBus;
@@ -231,9 +238,11 @@ public class SendOnlyEndpointGeneratorTests
             }
             """;
 
-        SourceGeneratorTest.ForIncrementalGenerator<SendOnlyEndpointGenerator>()
+        var result = SourceGeneratorTest.ForIncrementalGenerator<SendOnlyEndpointGenerator>()
             .WithSource(source)
             .Run();
+
+        Assert.That(result.GeneratorDiagnostics, Has.None.Matches<Diagnostic>(d => d.Id == DiagnosticIds.InvalidSendOnlyEndpointMethod));
     }
 
     #region Helpers

--- a/src/Tests.Analyzers/TestSources.cs
+++ b/src/Tests.Analyzers/TestSources.cs
@@ -1,7 +1,20 @@
 namespace NServiceBus.AzureFunctions.Analyzers.Tests;
 
+using System.Collections.Generic;
+using NUnit.Framework;
+
 static class TestSources
 {
+    public static IEnumerable<TestCaseData> EndpointNameSanitizationCases
+    {
+        get
+        {
+            yield return new TestCaseData("my-endpoint", "Configuremyendpoint");
+            yield return new TestCaseData("process.order", "Configureprocessorder");
+            yield return new TestCaseData("my_endpoint", "Configuremyendpoint");
+            yield return new TestCaseData("ProcessOrder", "configureprocessorder");
+        }
+    }
     public const string OrdinaryFunctionOnly = """
         using System.Threading;
         using System.Threading.Tasks;

--- a/src/Tests.Analyzers/TestSources.cs
+++ b/src/Tests.Analyzers/TestSources.cs
@@ -1,20 +1,7 @@
 namespace NServiceBus.AzureFunctions.Analyzers.Tests;
 
-using System.Collections.Generic;
-using NUnit.Framework;
-
 static class TestSources
 {
-    public static IEnumerable<TestCaseData> EndpointNameSanitizationCases
-    {
-        get
-        {
-            yield return new TestCaseData("my-endpoint", "Configuremyendpoint");
-            yield return new TestCaseData("process.order", "Configureprocessorder");
-            yield return new TestCaseData("my_endpoint", "Configuremyendpoint");
-            yield return new TestCaseData("ProcessOrder", "configureprocessorder");
-        }
-    }
     public const string OrdinaryFunctionOnly = """
         using System.Threading;
         using System.Threading.Tasks;


### PR DESCRIPTION
## Problem

The source generator derived the expected configure method name from the function/endpoint name by stripping all non-alphanumeric characters and prepending `Configure`. It then required an **exact** (case-insensitive) match against class members.

This meant users were locked into a single canonical spelling. For example, an endpoint named `"billing-backend"` required the method to be named `ConfigureBillingbackend` — names like `ConfigureBilling_Backend` or `ConfigureBilling_BackEnd` were rejected with a hard error.

## Solution

Instead of deriving one canonical name and requiring an exact match, the generator now **enumerates method candidates** and matches by pattern:

1. A candidate must start with `Configure` (case-insensitive)
2. The suffix after `Configure` is normalized (non-alphanumeric characters stripped)
3. The normalized suffix must match the normalized endpoint name (case-insensitive)

This accepts any reasonable spelling the user chooses while still maintaining a clear convention. For both function endpoints and send-only endpoints, the following all match endpoint name `"my-endpoint"`:

- `ConfigureMyEndpoint`
- `ConfigureMy_Endpoint`
- `Configuremy_endpoint`
- `ConfigureMYENDPOINT`

### Why not worry about false matches?

Three layers prevent accidental matches:

1. **Signature validation** — `ConfigureMethodResolver` requires the first parameter to be `EndpointConfiguration` and validates remaining parameters against the delegate type. A spuriously-named method would fail this check.
2. **Ambiguity detection** — If two methods both match the pattern (e.g., `ConfigureBillingApi` and `ConfigureBilling_Api` for endpoint `"billing-api"`), the existing `NSBFUNC004` diagnostic fires, telling the user to disambiguate.
3. **Convention prefix** — Methods must start with `Configure`, which is a narrow enough namespace that collisions with unrelated methods are unlikely in practice.

### What changed

- **`KnownTypeNames`** — Extracted `Normalize()` and `IsConfigureMethodFor()` from the old `ConfigureMethodName()`. The canonical name generator is preserved for diagnostic messages and the code fix provider.
- **`FunctionEndpointGenerator.Parser`** — `GetConfigureMethodSpec` uses pattern matching instead of exact string equality.
- **`SendOnlyEndpointGenerator.Parser`** — Same pattern-based matching. Error message updated to guide users toward the convention rather than prescribing one specific name.
- **Tests** — Replaced `SanitizesConfigureMethod` with `FlexibleConfigureMethodNameMatches` theory tests covering both canonical names and flexible variants (underscores, mixed casing, lowercase prefix).