### PR TITLE
Fix configure method discovery to accept more flexible naming conventions

### DIFF
--- a/src/NServiceBus.AzureFunctions.Analyzer/FunctionEndpointGenerator.Parser.cs
+++ b/src/NServiceBus.AzureFunctions.Analyzer/FunctionEndpointGenerator.Parser.cs
@@ -464,16 +464,17 @@ public sealed partial class FunctionEndpointGenerator
 
         static ConfigureMethodSpec? GetConfigureMethodSpec(INamedTypeSymbol functionClassType, string endpointName, FunctionEndpointGeneratorKnownTypes knownTypes, List<Diagnostic> diagnostics)
         {
-            var configureMethodName = KnownTypeNames.ConfigureMethodName(endpointName);
+            var normalizedEndpointName = KnownTypeNames.Normalize(endpointName);
 
             IMethodSymbol? configureMethod = null;
             foreach (var member in functionClassType.GetMembers())
             {
-                if (member is IMethodSymbol method && method.Name == configureMethodName)
+                if (member is IMethodSymbol method && KnownTypeNames.IsConfigureMethodFor(method.Name, normalizedEndpointName))
                 {
                     if (configureMethod is not null)
                     {
-                        diagnostics.Add(functionClassType.CreateDiagnostic(DiagnosticIds.MultipleConfigureMethodsDescriptor, configureMethodName, functionClassType.Name));
+                        var suggestedName = KnownTypeNames.ConfigureMethodName(endpointName);
+                        diagnostics.Add(functionClassType.CreateDiagnostic(DiagnosticIds.MultipleConfigureMethodsDescriptor, suggestedName, functionClassType.Name));
                         return null;
                     }
 

--- a/src/NServiceBus.AzureFunctions.Analyzer/KnownTypeNames.cs
+++ b/src/NServiceBus.AzureFunctions.Analyzer/KnownTypeNames.cs
@@ -2,7 +2,66 @@ namespace NServiceBus.AzureFunctions.Analyzer;
 
 static class KnownTypeNames
 {
-    public static string ConfigureMethodName(string endpointName) => $"Configure{endpointName}";
+    const string ConfigurePrefix = "Configure";
+
+    public static string ConfigureMethodName(string endpointName)
+    {
+        if (endpointName == null)
+        {
+            throw new ArgumentNullException(nameof(endpointName));
+        }
+
+        var normalized = Normalize(endpointName);
+        if (normalized.Length == 0)
+        {
+            throw new ArgumentException(
+                $"Cannot generate a valid C# configuration method name from endpoint name '{endpointName}' because it does not contain any ASCII letters or digits.",
+                nameof(endpointName));
+        }
+
+        return $"{ConfigurePrefix}{normalized}";
+    }
+
+    public static string Normalize(string name)
+    {
+        if (name == null)
+        {
+            return string.Empty;
+        }
+
+        var buffer = new char[name.Length];
+        var count = 0;
+
+        foreach (var c in name)
+        {
+            if (char.IsLetterOrDigit(c))
+            {
+                buffer[count++] = c;
+            }
+        }
+
+        return count == 0 ? string.Empty : count == name.Length ? name : new string(buffer, 0, count);
+    }
+
+    public static bool IsConfigureMethodFor(string methodName, string normalizedEndpointName)
+    {
+        if (!methodName.StartsWith(ConfigurePrefix, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        if (methodName.Length == ConfigurePrefix.Length)
+        {
+            return false;
+        }
+
+        var suffix = methodName.Substring(ConfigurePrefix.Length);
+        var normalizedSuffix = Normalize(suffix);
+
+        return normalizedSuffix.Length > 0
+            && string.Equals(normalizedSuffix, normalizedEndpointName, StringComparison.OrdinalIgnoreCase);
+    }
+
     public const string GeneratedCompositionNamespace = "NServiceBus";
     public const string GeneratedFunctionsCompositionFullName = "NServiceBus.NServiceBusGeneratedFunctionsComposition";
     public const string FunctionAttribute = "Microsoft.Azure.Functions.Worker.FunctionAttribute";

--- a/src/NServiceBus.AzureFunctions.Analyzer/SendOnlyEndpointGenerator.Parser.cs
+++ b/src/NServiceBus.AzureFunctions.Analyzer/SendOnlyEndpointGenerator.Parser.cs
@@ -59,10 +59,11 @@ public sealed partial class SendOnlyEndpointGenerator
                 problems.Add("method must be static");
             }
 
-            var expectedMethodName = KnownTypeNames.ConfigureMethodName(endpointName);
-            if (!string.Equals(method.Name, expectedMethodName, StringComparison.OrdinalIgnoreCase))
+            var normalizedEndpointName = KnownTypeNames.Normalize(endpointName);
+            if (!KnownTypeNames.IsConfigureMethodFor(method.Name, normalizedEndpointName))
             {
-                problems.Add($"method name must be '{expectedMethodName}'");
+                var expectedMethodName = KnownTypeNames.ConfigureMethodName(endpointName);
+                problems.Add($"method name must follow the 'Configure{{EndpointName}}' convention matching '{expectedMethodName}'");
             }
 
             var resolution = ConfigureMethodResolver.Resolve(method, knownTypes.EndpointConfiguration, knownTypes.DelegateType);

--- a/src/Tests.Analyzers/FunctionEndpointGeneratorTests.cs
+++ b/src/Tests.Analyzers/FunctionEndpointGeneratorTests.cs
@@ -16,6 +16,49 @@ public class FunctionEndpointGeneratorTests
             .Approve()
             .AssertRunsAreEqual();
 
+    [TestCase("my-endpoint", "Configuremyendpoint")]
+    [TestCase("process.order", "Configureprocessorder")]
+    [TestCase("my_endpoint", "Configuremyendpoint")]
+    [TestCase("ProcessOrder", "configureprocessorder")]
+    [TestCase("my-endpoint", "ConfigureMy_Endpoint")]
+    [TestCase("my-endpoint", "Configuremy_endpoint")]
+    [TestCase("ProcessOrder", "CONFIGUREprocessORDER")]
+    [TestCase("ProcessOrder", "configure_process_order")]
+    [TestCase("Lösung-Endpoint", "ConfigureLösungEndpoint")]
+    public void FlexibleConfigureMethodNameMatches(string endpointName, string configureMethodName)
+    {
+        var source = $$"""
+        using System.Threading;
+        using System.Threading.Tasks;
+        using Azure.Messaging.ServiceBus;
+        using Microsoft.Azure.Functions.Worker;
+        using Microsoft.Extensions.Configuration;
+        using Microsoft.Extensions.Hosting;
+        using NServiceBus;
+
+        namespace Demo;
+
+        public partial class Functions
+        {
+            [NServiceBusFunction]
+            [Function("{{endpointName}}")]
+            public partial Task Run(
+                [ServiceBusTrigger("sales-queue", AutoCompleteMessages = false)] ServiceBusReceivedMessage message,
+                ServiceBusMessageActions messageActions,
+                FunctionContext context,
+                CancellationToken cancellationToken);
+
+            public static void {{configureMethodName}}(EndpointConfiguration endpointConfiguration)
+            {
+            }
+        }
+        """;
+
+        SourceGeneratorTest.ForIncrementalGenerator<FunctionEndpointGenerator>()
+            .WithSource(source)
+            .Run();
+    }
+
     [Test]
     public void GeneratesFunctionEndpointInGlobalNamespace() =>
         SourceGeneratorTest.ForIncrementalGenerator<FunctionEndpointGenerator>()
@@ -655,6 +698,8 @@ public class FunctionEndpointGeneratorTests
             using Microsoft.Azure.Functions.Worker;
             using NServiceBus;
 
+            #nullable enable
+
             namespace Demo.Testing;
 
             [System.AttributeUsage(System.AttributeTargets.Parameter)]
@@ -668,6 +713,11 @@ public class FunctionEndpointGeneratorTests
             public static class TestFunctionManifestRegistration
             {
                 public static void Register(global::Microsoft.Azure.Functions.Worker.Builder.FunctionsApplicationBuilder _, global::NServiceBus.FunctionManifest __) { }
+            }
+
+            public class TestProcessor
+            {
+                public Task Process(string message, FunctionContext context, CancellationToken cancellationToken) => Task.CompletedTask;
             }
 
             {{classBody}}

--- a/src/Tests.Analyzers/SendOnlyEndpointGeneratorTests.cs
+++ b/src/Tests.Analyzers/SendOnlyEndpointGeneratorTests.cs
@@ -128,7 +128,7 @@ public class SendOnlyEndpointGeneratorTests
             }
             """);
 
-        Assert.That(diagnostic.GetMessage(), Does.Contain("method name must be 'Configureclient'"));
+        Assert.That(diagnostic.GetMessage(), Does.Contain("method name must follow the 'Configure{EndpointName}' convention matching 'Configureclient'"));
     }
 
     [Test]
@@ -210,8 +210,40 @@ public class SendOnlyEndpointGeneratorTests
 
         var message = diagnostic.GetMessage();
         Assert.That(message, Does.Contain("method must be static"));
-        Assert.That(message, Does.Contain("method name must be 'Configureclient'"));
+        Assert.That(message, Does.Contain("method name must follow the 'Configure{EndpointName}' convention matching 'Configureclient'"));
         Assert.That(message, Does.Contain("first parameter must be EndpointConfiguration"));
+    }
+
+    [TestCase("my-endpoint", "Configuremyendpoint")]
+    [TestCase("process.order", "Configureprocessorder")]
+    [TestCase("my_endpoint", "Configuremyendpoint")]
+    [TestCase("ProcessOrder", "configureprocessorder")]
+    [TestCase("my-endpoint", "ConfigureMy_Endpoint")]
+    [TestCase("my-endpoint", "Configuremy_endpoint")]
+    [TestCase("ProcessOrder", "CONFIGUREprocessORDER")]
+    [TestCase("ProcessOrder", "configure_process_order")]
+    [TestCase("Lösung-Endpoint", "ConfigureLösungEndpoint")]
+    public void FlexibleConfigureMethodNameMatches(string endpointName, string configureMethodName)
+    {
+        var source = $$"""
+            using NServiceBus;
+
+            namespace Demo;
+
+            public static class ClientEndpoint
+            {
+                [NServiceBusSendOnlyFunction("{{endpointName}}")]
+                public static void {{configureMethodName}}(EndpointConfiguration endpointConfiguration)
+                {
+                }
+            }
+            """;
+
+        var result = SourceGeneratorTest.ForIncrementalGenerator<SendOnlyEndpointGenerator>()
+            .WithSource(source)
+            .Run();
+
+        Assert.That(result.GeneratorDiagnostics, Has.None.Matches<Diagnostic>(d => d.Id == DiagnosticIds.InvalidSendOnlyEndpointMethod));
     }
 
     #region Helpers


### PR DESCRIPTION
Backport of #128 to `release-1.0`

### Symptoms

The source generator required the configure method name to follow an exact canonical form. For an endpoint named `"my-backend"`, only `ConfigureMybackend` was accepted. Names like `ConfigureMy_Backend`, `ConfigureMyBackend`, or `configure_my_backend` were rejected with the error `NSBFUNC006: missing 'ConfigureMybackend' configuration method`, even though the method existed and had a valid signature.

### Who's affected

You are affected if you have endpoint names containing non-alphanumeric characters (such as hyphens, dots, or underscores) and you prefer to use those characters in your configure method name — for example, naming the method `ConfigureMy_Backend` for an endpoint named `"my-backend"`.

### Root cause

See #128

### Confirmed workarounds

None